### PR TITLE
Adds Basic Gps Api

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -11,6 +11,7 @@ AddEventHandler('getUtils', function(cb)
     UtilAPI.Events = EventsAPI
     UtilAPI.Destruct = DestructionAPI
     UtilAPI.Render = RenderAPI
+    UtilAPI.Gps = GpsApi
 
     cb(UtilAPI)
 end)

--- a/client/services/gps.lua
+++ b/client/services/gps.lua
@@ -1,0 +1,13 @@
+GpsApi = {}
+
+function GpsApi:SetGps(x, y, z)
+    local pl = GetEntityCoords(PlayerPedId())
+    StartGpsMultiRoute(6, true, true)
+    AddPointToGpsMultiRoute(pl.x, pl.y, pl.z)
+    AddPointToGpsMultiRoute(x, y, z)
+    SetGpsMultiRouteRender(true)
+end
+
+function GpsApi:RemoveGps()
+    ClearGpsMultiRoute()
+end


### PR DESCRIPTION
This adds basic Gps Api to vorp_utils. I use Gps alot, and I use vorp_utils alot. This just makes it easy to set and remove gps waypoints using vorp_utils!

Adds 2 functions:
VORPutils.Gps:SetGps(x, y, z) --Creates the gps waypoint

VORPutils.Gps:RemoveGps() --Removes the gps waypoint

Gps are not hard to set with natives, but this just makes it simple to do, and adds another tool too vorp_utils list.