### PR TITLE
Added an export to get utils

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,18 +1,22 @@
+local UtilAPI = {}
+
+UtilAPI.General = GeneralAPI
+UtilAPI.Prompts = PromptsAPI
+UtilAPI.Blips = BlipAPI
+UtilAPI.Peds = PedAPI
+UtilAPI.DataView = DataView
+UtilAPI.Print = PrintAPI
+UtilAPI.Objects = ObjectAPI
+UtilAPI.Events = EventsAPI
+UtilAPI.Destruct = DestructionAPI
+UtilAPI.Render = RenderAPI
+UtilAPI.Gps = GpsApi
+UtilAPI.Shared = Shared
+
 AddEventHandler('getUtils', function(cb)
-    local UtilAPI = {}
-
-    UtilAPI.General = GeneralAPI
-    UtilAPI.Prompts = PromptsAPI
-    UtilAPI.Blips = BlipAPI
-    UtilAPI.Peds = PedAPI
-    UtilAPI.DataView = DataView
-    UtilAPI.Print = PrintAPI
-    UtilAPI.Objects = ObjectAPI
-    UtilAPI.Events = EventsAPI
-    UtilAPI.Destruct = DestructionAPI
-    UtilAPI.Render = RenderAPI
-    UtilAPI.Gps = GpsApi
-    UtilAPI.Shared = Shared
-
     cb(UtilAPI)
+end)
+
+exports('GetUtils', function()
+    return UtilAPI
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,10 +1,14 @@
-AddEventHandler('getUtils', function(cb)
-    local UtilAPI = {}
+local UtilAPI = {}
 
-    UtilAPI.General = GeneralAPI
-    UtilAPI.Files = FilesAPI
-    UtilAPI.Print = PrintAPI
-    UtilAPI.DataView = DataView
-    
+UtilAPI.General = GeneralAPI
+UtilAPI.Files = FilesAPI
+UtilAPI.Print = PrintAPI
+UtilAPI.DataView = DataView
+
+AddEventHandler('getUtils', function(cb)
     cb(UtilAPI)
+end)
+
+exports('GetUtils', function()
+    return UtilAPI
 end)


### PR DESCRIPTION
This should allow to get the utils like this:
```lua
local VORPutils = exports.vorp_utils:GetUtils()
```
in a similar way to how vorp core is taken with exports instead of `TriggerEvent`.
This should improve code consistency for developers using both vorp core and vorp utils.